### PR TITLE
Exercise the goto in Nonlocal_Goto test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# These two lines makes us ignore executable files.
+*	# Ignore ALL files.
+!*.*	# Allow those that have an extension
 fpc-build
 gpc-build
 vpc-build
+lpc-build
+*.o

--- a/complex_numbers.pas
+++ b/complex_numbers.pas
@@ -27,12 +27,17 @@ begin
   WriteLn(Re(x):1:3, '+', Im(x):1:3, 'i');
 end;
 
+procedure print_real(x: real);
+begin
+   WriteLn(x:1:3);
+end;
+
 begin
   c := Cmplx(2, 3);
   print_complex(c);
-  print_complex(Abs(c));
+  print_real(Abs(c));
   print_complex(Arctan(c));
-  print_complex(Arg(c));
+  print_real(Arg(c));
   print_complex(Cos(c));
   print_complex(Exp(c));
   print_complex(Ln(c));

--- a/lpc
+++ b/lpc
@@ -1,0 +1,33 @@
+#! /bin/sh
+
+# Run the tests with FPC
+rm -fr lpc-build
+mkdir lpc-build
+cd lpc-build
+
+if test -z "$FPC";
+then
+    LPC="../../lacsap/lacsap"
+fi
+
+pc=$LPC
+for f in ../*.pas;
+do
+    # Try with different versions and modes until something works
+    # *nix only at the moment
+    $pc $f
+    err=$?
+    if test "$err" = "0";
+    then
+        echo "$f" >> success
+    fi
+
+    if test "$err" != "0";
+    then
+        echo "$f" >> failure 
+    fi
+done
+echo failures:
+wc -l failure
+echo successes:
+wc -l success

--- a/nonlocal_goto.pas
+++ b/nonlocal_goto.pas
@@ -28,6 +28,7 @@ begin
 end;
 
 begin
+  p;
   2:
   begin
     WriteLn('Correctly made it to extraprocedural label 2');


### PR DESCRIPTION
Call the function that does goto back to the "main" program.

I _think_ this is what the test was intending to do, since if `p` is never called, the non-local `goto` is not actually happening. 

I'm not able to actually test this at this point, as my own compiler (https://github.com/Leporacanthicus/lacsap) doesn't support non-local goto, neither does the FPC version I'm using.